### PR TITLE
Generate correct path to resources when using the Mount plugin

### DIFF
--- a/lib/Mojolicious/Plugin/StaticCompressor.pm
+++ b/lib/Mojolicious/Plugin/StaticCompressor.pm
@@ -78,6 +78,13 @@ sub register {
 							$containers{$cont->get_key()} = $cont;
 						}
 						
+						my $headers = $self->req->headers;
+						if (my $date = $headers->if_modified_since) {
+							my $since = Mojo::Date->new($date)->epoch;
+							$self->res->code(304) if defined $since && $since == $cont->get_last_updated();
+						}
+						
+						$self->res->headers->last_modified(Mojo::Date->new($cont->get_last_updated()));
 						$self->render( text => $cont->get_content(), format => $cont->get_extension() );
 					};
 

--- a/lib/Mojolicious/Plugin/StaticCompressor/Container.pm
+++ b/lib/Mojolicious/Plugin/StaticCompressor/Container.pm
@@ -62,6 +62,12 @@ sub get_key {
 	return $s->{key};
 }
 
+# Get the timestamp for the last update
+sub get_last_updated {
+	my $s = shift;
+	return $s->{last_updated};
+}
+
 # Get the extension
 sub get_extension {
 	my $s = shift;
@@ -124,6 +130,8 @@ sub _load_from_cache {
 		};
 		if($@){ die("Can't read the cache file:". $path_cache_file); }
 
+		$s->{last_updated} = (stat $path_cache_file)[9];		
+		
 		# Parse the file
 		if($content =~ /^\/\*-{5}StaticCompressor-{5}\n((.+\n)+?)-{10}\*\/\n/){
 			my @paths = split("\n", $1);
@@ -210,6 +218,8 @@ EOF
 	$cache->add_chunk( Encode::encode_utf8($save_header.$content) );
 	$cache->move_to( $path_cache_file );
 
+	$s->{last_updated} = time;
+	
 	return 1;
 }
 

--- a/t/04.baisc_mounted.t
+++ b/t/04.baisc_mounted.t
@@ -1,0 +1,25 @@
+# Test for basic use of StaticCompressor
+use strict;
+use warnings;
+
+use Mojolicious::Lite;
+use Test::More;
+use Test::Mojo;
+use FindBin;
+use File::Slurp;
+use JavaScript::Minifier qw();
+
+plugin Mount => {'/prefix' => "$FindBin::Bin/foo.pl"};
+
+# Test for HTML-tag (script tag, single compressed-file)
+my $t = Test::Mojo->new;
+$t->get_ok('/prefix/foo')->status_is(200)->content_like(qr/<script src="(.+)"><\/script>/);
+$t->tx->res->body =~ /<script src="(\/prefix\/auto_compressed\/.+)"><\/script>/;
+my $script_path = $1;
+# Test for script (single compressed js)
+$t->get_ok($script_path)->status_is(200)->content_type_like(qr/application\/javascript\.*/)
+	->content_is( JavaScript::Minifier::minify(input => File::Slurp::read_file("$FindBin::Bin/public/js/foo.js") ."") );
+
+done_testing();
+
+=cut

--- a/t/foo.pl
+++ b/t/foo.pl
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+
+# Prepare a test app with Plugin
+use Mojolicious::Lite;
+plugin('StaticCompressor');
+
+get '/foo' => sub {
+	# HTML page (include single js) - t/templates/foo.html.ep
+	my $self = shift;
+	$self->render;
+};
+
+app->start;


### PR DESCRIPTION
When using the Mount plugin we cannot just set the path to /auto_compressed because the application will be under a prefix. This patch uses the Controller url_for method to get the correct root.
